### PR TITLE
LatencyStats Integration Work

### DIFF
--- a/scripts/build_MetricBench.sh
+++ b/scripts/build_MetricBench.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-# build MetricBench on Ubuntu 12.04
+# build MetricBench
+#
+# Currently supports Ubuntu 12 / 14
 
 # david.bennett at percona.com - 6/9/2015
 
@@ -35,10 +37,8 @@ apt-get install -y --force-yes \
 cd /usr/bin
 for CMD in cpp gcc g++; do
   [ -L ${CMD} ] && rm ${CMD}
+  ln -s ${CMD}-4.8 ${CMD}
 done 
-ln -s cpp-4.8 cpp
-ln -s gcc-4.8 gcc
-ln -s g++-4.8 g++
 
 # --- user section (does not require root) ---
 
@@ -47,7 +47,7 @@ ln -s g++-4.8 g++
 mkdir ${BUILD_ROOT}
 cd ${BUILD_ROOT}
 wget -q -O - \
-        http://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.gz/download \
+        http://sf.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.gz/download \
         | tar xzvf -
 cd boost_1_58_0
 BOOST_ROOT=${BUILD_ROOT}/MetricBench_boost

--- a/scripts/build_MetricBench.sh
+++ b/scripts/build_MetricBench.sh
@@ -8,6 +8,7 @@
 
 # Note: you will need to run as root for the first section
 
+BUILD_STATIC=0
 BUILD_ROOT=${HOME}/build
 
 # --- root section ---
@@ -55,7 +56,11 @@ mkdir -p ${BOOST_ROOT}
 ./bootstrap.sh --prefix=${BOOST_ROOT} \
         --libdir=${BOOST_ROOT}/lib --includedir=${BOOST_ROOT}/include \
         --with-libraries=program_options,filesystem,system,test
-./b2 --build-type=complete --layout=tagged link=static install | tee b2.out
+if [ "${BUILD_STATIC}" -gt 0 ]; then
+  ./b2 --build-type=complete --layout=tagged link=static install | tee b2.out
+else
+  ./b2 --build-type=complete --layout=tagged link=shared install | tee b2.out
+fi
 export BOOST_ROOT
 
 # MySQL Connector C++ - 1.1.5
@@ -75,7 +80,11 @@ cd ${BUILD_ROOT}
 git clone https://github.com/Percona-Lab/MetricBench.git
 cd MetricBench/src
 ./clean.sh all
-cmake -DMYSQLCONNECTORCPP_ROOT_DIR:PATH=${MYSQLCONNECTORCPP_ROOT_DIR} .
+if [ "${BUILD_STATIC}" -gt 0 ]; then
+  cmake -DBUILD_STATIC=1 -DMYSQLCONNECTORCPP_ROOT_DIR:PATH=${MYSQLCONNECTORCPP_ROOT_DIR} .
+else
+  cmake -DMYSQLCONNECTORCPP_ROOT_DIR:PATH=${MYSQLCONNECTORCPP_ROOT_DIR} .
+fi
 make
 
 # Epilogue 

--- a/scripts/build_MetricBench.sh
+++ b/scripts/build_MetricBench.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 
-# build MetricBench
+# build MetricBench on a barebones Ubuntu 12/14 
+# this script does everything, installs toolchain
+# and dependencies, downloads and builds
+# MySQL Connector C++ and Boost
+# and downloads and builds MetricBench.
+# You can run this on a clean docker or vagrant image
+# of Ubuntu 12/14 x86_64
+#
+# If you are building somewhere else or just need part
+# of this script it should be easy as pie to copy & paste
 #
 # Currently supports Ubuntu 12 / 14
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,29 +1,57 @@
 cmake_minimum_required (VERSION 2.6)
 project (MetricBench)
 
+# determine if a static or dynamic binary should be built
+
+if (BUILD_STATIC)
+  message(STATUS "Building static binary")
+  set(MYSQLCPPCONN_LIB_NAME "mysqlcppconn-static")
+  set(Boost_USE_STATIC_LIBS ON)
+  set(CXX_BUILD_FLAGS "-static")
+  set(LINK_BUILD_FLAGS "-static -pthread -Wl,--no-as-needed")
+  set(PTHREAD_LIB "-Wl,--whole-archive -lpthread -Wl,--no-whole-archive")
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+  set(BUILD_SHARED_LIBRARIES OFF)
+  set(CMAKE_EXE_LINK_DYNAMIC_CXX_FLAGS)
+  set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS)
+else()
+  message(STATUS "Building a dynamically linked binary")
+  set(MYSQLCPPCONN_LIB_NAME "mysqlcppconn")
+  set(Boost_USE_STATIC_LIBS OFF)
+  set(CXX_BUILD_FLAGS "")
+  set(LINK_BUILD_FLAGS "")
+  set(PTHREAD_LIB "pthread")
+  set(BUILD_SHARED_LIBRARIES ON)
+endif()
+
+# Find the MySQL library locations
+
 set(MYSQLCONNECTORCPP_ROOT_DIR
-	"${MYSQLCONNECTORCPP_ROOT_DIR}"
-	CACHE
-	PATH
-	"Where to start looking for this component.")
+        "${MYSQLCONNECTORCPP_ROOT_DIR}"
+        CACHE
+        PATH
+        "Where to start looking for this component.")
 
-	find_path(MYSQLCONNECTORCPP_INCLUDE_DIR
-		mysql_connection.h
-		HINTS
-		${MYSQLCONNECTORCPP_ROOT_DIR}
-		PATH_SUFFIXES
-		include)
+find_path(MYSQLCONNECTORCPP_INCLUDE_DIR
+        mysql_connection.h
+        HINTS
+        ${MYSQLCONNECTORCPP_ROOT_DIR}
+        PATH_SUFFIXES
+        include)
 
-	find_library(MYSQLCONNECTORCPP_LIBRARY
-		NAMES
-		mysqlcppconn-static
-		HINTS
-		${MYSQLCONNECTORCPP_ROOT_DIR}
-		PATH_SUFFIXES
-		lib64
-                lib64/mysql
-		lib
-                lib/mysql)
+find_library(MYSQLCONNECTORCPP_LIBRARY
+        NAMES
+        ${MYSQLCPPCONN_LIB_NAME}
+        HINTS
+        ${MYSQLCONNECTORCPP_ROOT_DIR}
+        PATH_SUFFIXES
+        lib64
+        lib64/mysql
+        lib
+        lib/mysql
+        lib/x86_64-linux-gnu)
+
+message(STATUS ${MYSQLCONNECTORCPP_LIBRARY})
 
 find_library(MYSQL_CLIENT
         NAMES
@@ -35,38 +63,55 @@ find_library(MYSQL_CLIENT
 
 message(STATUS ${MYSQL_CLIENT})
 
-set(Boost_USE_STATIC_LIBS ON)
+# Configure Boost packages
+
 find_package(Boost REQUIRED COMPONENTS program_options system filesystem)
-include_directories( ${Boost_INCLUDE_DIRS} )
+
+# Configure header directories
+
+include_directories( ${Boost_INCLUDE_DIRS} ${MYSQLCONNECTORCPP_INCLUDE_DIR} )
+
+# MySQL client C/C++ headers and libraries are required
 
 mark_as_advanced(MYSQLCONNECTORCPP_INCLUDE_DIR MYSQLCONNECTORCPP_LIBRARY)
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(MysqlConnectorCpp
-	DEFAULT_MSG
-	MYSQLCONNECTORCPP_INCLUDE_DIR
-	MYSQLCONNECTORCPP_LIBRARY)
+        DEFAULT_MSG
+        MYSQLCONNECTORCPP_INCLUDE_DIR
+        MYSQLCONNECTORCPP_LIBRARY)
 
-set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++")
+# Global compiler flags
 
-add_executable(MetricBench metricbench.cpp Preparer.cpp MySQLDriver.cpp Config.cpp Stats.cpp Message.cpp)
+set(GCC_COVERAGE_COMPILE_FLAGS "-std=c++11 -pedantic ${CXX_BUILD_FLAGS}")
+add_definitions(${GCC_COVERAGE_COMPILE_FLAGS})
+
+# MetricBench binary settings
+
+add_executable(MetricBench metricbench.cpp Preparer.cpp MySQLDriver.cpp Config.cpp 
+  Stats.cpp Message.cpp RunningMean.cpp LatencyStats.cpp)
+
 set_target_properties(MetricBench PROPERTIES
-		LINK_FLAGS "-L/usr/local/lib/x86_64-linux-gnu/"
-		COMPILE_FLAGS "-std=c++11")
-#target_link_libraries (MetricBench mysqlcppconn-static mysqlclient)
-target_link_libraries (MetricBench mysqlcppconn-static ${MYSQL_CLIENT} pthread m rt dl z
-    ${Boost_LIBRARIES})
-#    ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_QUEUE_LIBRARY})
+  LINK_FLAGS "${LINK_BUILD_FLAGS}")
 
+target_link_libraries (MetricBench ${MYSQLCONNECTORCPP_LIBRARY} ${MYSQL_CLIENT}
+  ${Boost_LIBRARIES} ${PTHREAD_LIB} m rt dl z c)
 
 # Unit Tests
 
 enable_testing()
+
+# Boost unit test framework is required
 
 find_package(Boost COMPONENTS unit_test_framework REQUIRED)
 include_directories (${Boost_INCLUDE_DIRS})
 
 #I like to keep test files in a separate source directory called test
 file(GLOB TEST_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} test/*.cpp)
+
+if(BUILD_STATIC)
+else()
+  add_definitions(-DBOOST_TEST_DYN_LINK) 
+endif()
 
 #Run through each source
 foreach(testSrc ${TEST_SRCS})
@@ -78,15 +123,15 @@ foreach(testSrc ${TEST_SRCS})
 
         #link to Boost libraries AND your targets and dependencies
         target_link_libraries(${testName} ${Boost_LIBRARIES}
-            mysqlcppconn-static ${MYSQL_CLIENT} pthread m rt dl z )
+             ${MYSQLCONNECTORCPP_LIBRARY} ${MYSQL_CLIENT} pthread m rt dl z )
 
         #I like to move testing binaries into a testBin directory
-        set_target_properties(${testName} PROPERTIES 
+        set_target_properties(${testName} PROPERTIES
             RUNTIME_OUTPUT_DIRECTORY  ${CMAKE_CURRENT_SOURCE_DIR}/testBin)
 
-        #Finally add it to test execution - 
+        #Finally add it to test execution -
         #Notice the WORKING_DIRECTORY and COMMAND
-        add_test(NAME ${testName} 
-                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testBin 
+        add_test(NAME ${testName}
+                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testBin
                  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/testBin/${testName} )
 endforeach(testSrc)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -119,7 +119,8 @@ foreach(testSrc ${TEST_SRCS})
         get_filename_component(testName ${testSrc} NAME_WE)
 
         #Add compile target
-        add_executable(${testName} ${testSrc} Message.cpp)
+        add_executable(${testName} ${testSrc} Message.cpp LatencyStats.cpp
+          RunningMean.cpp)
 
         #link to Boost libraries AND your targets and dependencies
         target_link_libraries(${testName} ${Boost_LIBRARIES}

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -16,4 +16,7 @@ namespace Config
     std::string connPass = Config::DEFAULT_PASS;
 
     RunModeE runMode = RUN;
+
+    std::string csvStatsFile = "";
+    std::string csvStreamingStatsFile = "";
 }

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -43,4 +43,7 @@ namespace Config
     extern std::string storageEngineExtra;
 
     extern RunModeE runMode;
+
+    extern std::string csvStatsFile;
+    extern std::string csvStreamingStatsFile;
 }

--- a/src/LatencyStats.cpp
+++ b/src/LatencyStats.cpp
@@ -23,7 +23,7 @@ LatencyStats::LatencyStats(int maxThreads) :
   bucketCountsCumulative(boost::extents[MAX_OPTYPES][NUM_BUCKETS])
 {
   // initialize our arrays
-  std::fill( means.origin(), means.origin() + means.size(),(RunningMean *)NULL);
+  std::fill( means.origin(), means.origin() + means.size(),(RunningMean *)nullptr);
   std::fill( bucketCounts.origin(), bucketCounts.origin() + bucketCounts.size(), 0);
   std::fill( maxLatency.origin(), maxLatency.origin() + maxLatency.size(), 0);
 }
@@ -93,7 +93,7 @@ void LatencyStats::recordLatency(int32_t threadid, MessageType type, int64_t mic
   opBuckets[bucket]++;
 
   auto time_ms = microtimetaken / 1000.0;
-  if (means[threadid][type] == (RunningMean *)NULL) {
+  if (means[threadid][type] == (RunningMean *)nullptr) {
     means[threadid][type] = new RunningMean(time_ms);
   } else {
     means[threadid][type]->addSample(time_ms);
@@ -113,7 +113,7 @@ void LatencyStats::displayLatencyStats()
   calcMeans();
   calcCumulativeBuckets();
 
-  for (int type; type < MAX_OPTYPES; type++) {
+  for (int type = 0; type < MAX_OPTYPES; type++) {
     if (sampleCounts[type] == 0) {
       continue;
     }
@@ -151,15 +151,15 @@ void LatencyStats::calcMeans()
 {
   for (int i = 0; i < MAX_OPTYPES; i++) {
     int64_t samples = 0;
-    for (int thread = 0; i < maxThreads; thread++) {
-      if (means[thread][i] != (RunningMean *)NULL) {
+    for (int thread = 0; thread < maxThreads; thread++) {
+      if (means[thread][i] != (RunningMean *)nullptr) {
         samples += means[thread][i]->samples();
       }
     }
     sampleCounts[i] = samples;
     double weightedMean = 0.0;
     for (int32_t thread = 0; thread < maxThreads; thread++) {
-      if (means[thread][i] != (RunningMean *)NULL) {
+      if (means[thread][i] != (RunningMean *)nullptr) {
         weightedMean += (means[thread][i]->samples() / static_cast< double >(samples)) *
           means[thread][i]->mean();
       }
@@ -201,7 +201,7 @@ LatencyStats::MinMaxMS LatencyStats::getBucketBounds(MessageType type, int64_t p
       break;
     }
   }
-  assert(bucketNum >= 0); // should be found
+  //assert(bucketNum >= 0); // should be found
   return LatencyStats::bucketBound(bucketNum);
 }
 

--- a/src/LatencyStats.cpp
+++ b/src/LatencyStats.cpp
@@ -1,0 +1,147 @@
+#include <algorithm>
+#include <cstddef>
+
+#include "LatencyStats.hpp"
+
+/**
+ * Ported from the LinkBench LatencyStats class
+ *
+ * david.bennett at percona.com - June 2015
+ *
+ */
+
+/**
+ * Class used to track and compute latency statistics, particularly
+ * percentiles. Times are divided into buckets, with counts maintained
+ * per bucket.  The division into buckets is based on typical latencies
+ * for database operations: most are in the range of 0.1ms to 100ms.
+ * we have 0.1ms-granularity buckets up to 1ms, then 1ms-granularity from
+ * 1-100ms, then 100ms-granularity, and then 1s-granularity.
+ */
+LatencyStats::LatencyStats(int maxThreads) :
+  maxThreads(maxThreads),
+  means(boost::extents[maxThreads][MAX_MILLIS]),
+  bucketCounts(boost::extents[maxThreads][MAX_OPTYPES][NUM_BUCKETS]),
+  maxLatency(boost::extents[maxThreads][MAX_OPTYPES]),
+  bucketCountsCumulative(boost::extents[MAX_OPTYPES][NUM_BUCKETS])
+{
+  // initialize our arrays
+  std::fill( means.origin(), means.origin() + means.size(),(RunningMean *)NULL);
+  std::fill( bucketCounts.origin(), bucketCounts.origin() + bucketCounts.size(), 0);
+  std::fill( maxLatency.origin(), maxLatency.origin() + maxLatency.size(), 0);
+}
+
+/**
+ * Determine which bucket to record operation based on latency value
+ *
+ */
+int32_t LatencyStats::latencyToBucket(int64_t microTime)
+{
+    int64_t ms = int32_t(1000);
+    auto msTime = microTime / ms;
+    if(msTime == 0) {
+        return static_cast< int32_t >((microTime / int32_t(100)));
+    } else if(msTime < 100) {
+        auto msBucket = static_cast< int32_t >(msTime) - int32_t(1);
+        return SUB_MS_BUCKETS + msBucket;
+    } else if(msTime < 1000) {
+        auto hundredMSBucket = static_cast< int32_t >((msTime / int32_t(100))) - int32_t(1);
+        return SUB_MS_BUCKETS + MS_BUCKETS + hundredMSBucket;
+    } else if(msTime < 10000) {
+        auto secBucket = static_cast< int32_t >((msTime / int32_t(1000))) - int32_t(1);
+        return SUB_MS_BUCKETS + MS_BUCKETS + HUNDREDMS_BUCKETS+ secBucket;
+    } else {
+        return NUM_BUCKETS - int32_t(1);
+    }
+}
+
+/**
+ *
+ * @param bucket
+ * @return inclusive min and exclusive max time in microsecs for bucket
+ */
+LatencyStats::MinMaxMS LatencyStats::bucketBound(int32_t bucket)
+{
+    auto ms = int32_t(1000);
+    int64_t s = ms * int32_t(1000);
+    LatencyStats::MinMaxMS res;
+    if(bucket < SUB_MS_BUCKETS) {
+        res[int32_t(0)] = bucket * int32_t(100);
+        res[int32_t(1)] = (bucket + int32_t(1)) * int32_t(100);
+    } else if(bucket < SUB_MS_BUCKETS + MS_BUCKETS) {
+        res[int32_t(0)] = (bucket - SUB_MS_BUCKETS + int32_t(1)) * ms;
+        res[int32_t(1)] = (bucket - SUB_MS_BUCKETS + int32_t(2)) * ms;
+    } else if(bucket < SUB_MS_BUCKETS + MS_BUCKETS + HUNDREDMS_BUCKETS) {
+        auto hundredMS = bucket - SUB_MS_BUCKETS - MS_BUCKETS + int32_t(1);
+        res[int32_t(0)] = hundredMS * int32_t(100) * ms;
+        res[int32_t(1)] = (hundredMS + int32_t(1)) * int32_t(100) * ms;
+    } else if(bucket < SUB_MS_BUCKETS + MS_BUCKETS + HUNDREDMS_BUCKETS+ SEC_BUCKETS) {
+        auto secBucket = bucket - SUB_MS_BUCKETS - MS_BUCKETS- SEC_BUCKETS + int32_t(1);
+        res[int32_t(0)] = secBucket * s;
+        res[int32_t(1)] = (secBucket + int32_t(1)) * s;
+    } else {
+        res[int32_t(0)] = (SEC_BUCKETS + int32_t(1)) * s;
+        res[int32_t(1)] = int32_t(100) * s;
+    }
+    return res;
+}
+
+/**
+ * This method is used to record the latency of each individual operation.
+ */
+void LatencyStats::recordLatency(int32_t threadid, MessageType type, int64_t microtimetaken)
+{
+  boost::multi_array<int64_t, 1> opBuckets = bucketCounts[threadid][type];
+  int bucket = latencyToBucket(microtimetaken);
+  opBuckets[bucket]++;
+
+  auto time_ms = microtimetaken / 1000.0;
+  if (means[threadid][type] == (RunningMean *)NULL) {
+    means[threadid][type] = new RunningMean(time_ms);
+  } else {
+    means[threadid][type]->addSample(time_ms);
+  }
+  if (maxLatency[threadid][type] < microtimetaken) {
+    maxLatency[threadid][type] = microtimetaken;
+  }
+}
+
+// TODO: displayLatencyStats
+//
+// TODO: printCSVStats
+//
+// TODO: printCSVStats(...)
+
+
+void LatencyStats::calcMeans()
+{
+  boost::array<int64_t, MAX_OPTYPES> sampleCounts={};
+  boost::array<double, MAX_OPTYPES> finalMeans={};
+
+  for (int i = 0; i < MAX_OPTYPES; i++) {
+    int64_t samples = 0;
+    for (int thread = 0; i < maxThreads; thread++) {
+      if (means[thread][i] != (RunningMean *)NULL) {
+        samples += means[thread][i]->samples();
+      }
+    }
+    sampleCounts[i] = samples;
+    double weightedMean = 0.0;
+    for (int32_t thread = 0; thread < maxThreads; thread++) {
+      if (means[thread][i] != (RunningMean *)NULL) {
+        weightedMean += (means[thread][i]->samples() / static_cast< double >(samples)) *
+          means[thread][i]->mean();
+      }
+    }
+    finalMeans[i] = weightedMean;
+  }
+}
+
+/**
+ * Calculate the cumulative operation counts by bucket for each type
+ */
+void LatencyStats::calcCumulativeBuckets()
+{
+  std::fill( bucketCountsCumulative.origin(),
+             bucketCountsCumulative.origin() + bucketCountsCumulative.size(), 0);
+}

--- a/src/LatencyStats.hpp
+++ b/src/LatencyStats.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <stdint.h>
+
+#include <boost/array.hpp>
+#include <boost/multi_array.hpp>
+
+#include "Message.hpp"
+#include "RunningMean.hpp"
+
+class LatencyStats {
+
+public:
+
+    const static int32_t MAX_MILLIS = 100;
+    const static int32_t MAX_OPTYPES = sizeof(MessageType);
+
+private:
+
+    const static int SUB_MS_BUCKETS = 10;   // Sub-ms granularity
+    const static int MS_BUCKETS = 99;       // ms-granularity buckets
+    const static int HUNDREDMS_BUCKETS = 9; // 100ms=granularity bucket
+    const static int SEC_BUCKETS = 9;       // 1s-granularity buckets
+
+    int maxThreads;
+
+    typedef boost::multi_array<RunningMean *, 2> RunningMeanArray;
+    RunningMeanArray means;
+
+    typedef boost::array<double, MAX_OPTYPES> FinalMeanArray;
+    FinalMeanArray finalMeans;
+
+    typedef boost::multi_array<int64_t, 3> BucketCountArray;
+    BucketCountArray bucketCounts;
+
+    typedef boost::multi_array<int64_t, 2> MaxLatencyArray;
+    MaxLatencyArray maxLatency;
+
+    typedef boost::array<int64_t, MAX_OPTYPES> SampleCountsArray;
+    SampleCountsArray sampleCounts;
+
+    typedef boost::multi_array<int64_t, 2> BucketCountsCumulativeArray;
+    BucketCountsCumulativeArray bucketCountsCumulative;
+
+    void calcMeans();
+    void calcCumulativeBuckets();
+
+public:
+    const static int NUM_BUCKETS = SUB_MS_BUCKETS + MS_BUCKETS +
+                                   HUNDREDMS_BUCKETS + SEC_BUCKETS + 1;
+
+    typedef boost::array<int64_t, 2> MinMaxMS;
+
+    LatencyStats(int maxThreads);
+    static int32_t latencyToBucket(int64_t microTime);
+    static MinMaxMS bucketBound(int32_t bucket);
+    void recordLatency(int32_t threadid, MessageType type, int64_t microtimetaken);
+
+};
+

--- a/src/LatencyStats.hpp
+++ b/src/LatencyStats.hpp
@@ -1,8 +1,15 @@
 #pragma once
 
-#include <stdint.h>
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <iostream>
+#include <string>
 
 #include <boost/array.hpp>
+#include <boost/foreach.hpp>
 #include <boost/multi_array.hpp>
 
 #include "Message.hpp"
@@ -14,6 +21,8 @@ public:
 
     const static int32_t MAX_MILLIS = 100;
     const static int32_t MAX_OPTYPES = sizeof(MessageType);
+
+    typedef boost::array<int64_t, 2> MinMaxMS;
 
 private:
 
@@ -28,7 +37,7 @@ private:
     RunningMeanArray means;
 
     typedef boost::array<double, MAX_OPTYPES> FinalMeanArray;
-    FinalMeanArray finalMeans;
+    FinalMeanArray finalMeans={};
 
     typedef boost::multi_array<int64_t, 3> BucketCountArray;
     BucketCountArray bucketCounts;
@@ -37,24 +46,74 @@ private:
     MaxLatencyArray maxLatency;
 
     typedef boost::array<int64_t, MAX_OPTYPES> SampleCountsArray;
-    SampleCountsArray sampleCounts;
+    SampleCountsArray sampleCounts={};
 
     typedef boost::multi_array<int64_t, 2> BucketCountsCumulativeArray;
     BucketCountsCumulativeArray bucketCountsCumulative;
 
+    // functions
+
     void calcMeans();
     void calcCumulativeBuckets();
+    MinMaxMS getBucketBounds(MessageType type, int64_t percentile);
+    static std::string boundsToString(MinMaxMS bucketBounds);
+    double getMean(MessageType type);
+    double getMax(MessageType type);
+    std::string percentileString(MessageType type, int64_t percentile);
 
 public:
     const static int NUM_BUCKETS = SUB_MS_BUCKETS + MS_BUCKETS +
                                    HUNDREDMS_BUCKETS + SEC_BUCKETS + 1;
 
-    typedef boost::array<int64_t, 2> MinMaxMS;
+    // functions
 
     LatencyStats(int maxThreads);
     static int32_t latencyToBucket(int64_t microTime);
     static MinMaxMS bucketBound(int32_t bucket);
     void recordLatency(int32_t threadid, MessageType type, int64_t microtimetaken);
+    void displayLatencyStats();
+    void printCSVStats(std::ostream &out, bool header);
 
+    // We are using a function template for CSV output because we don't know
+    // how many elements are in the ops array
+
+    template<std::size_t N>
+    void printCSVStats(std::ostream &out, bool header, boost::array<MessageType, N> &ops) {
+      boost::array<int,5> percentiles = {25, 50, 75, 95, 99};
+      char buf[128]; // love handles
+      char fmt2f[]="%.2f";
+      char fmt3f[]="%.3f";
+
+      if (header) {
+        out << "op,count";
+        BOOST_FOREACH( int p, percentiles) {
+          std::sprintf(buf,",p%d_low,p%d_high", p, p);
+          out << buf;
+        }
+        out << ",max,mean\n";
+      }
+
+      BOOST_FOREACH (MessageType msg, ops) {
+        int64_t samples = sampleCounts[msg];
+        if (samples == 0) {
+          continue;
+        }
+        out <<  messageTypeLabel[msg];
+        out << "," << samples;
+
+        BOOST_FOREACH (int p, percentiles) {
+          MinMaxMS bounds = getBucketBounds(msg, p);
+          for (int mm=0; mm < 2; mm++) {
+            std::sprintf(buf,fmt2f,bounds[mm] / 1000.0);
+            out << "," << buf;
+          }
+        }
+        std::sprintf(buf,fmt3f,getMax(msg));
+        out << "," << buf;
+        std::sprintf(buf,fmt3f,getMean(msg));
+        out << "," << buf;
+        out << "\n";
+      }
+    }
 };
 

--- a/src/MySQLDriver.hpp
+++ b/src/MySQLDriver.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <stdlib.h>
 #include <iostream>
 #include <iomanip>
@@ -21,6 +22,7 @@
 
 #include "pareto.hpp"
 #include "Config.hpp"
+#include "LatencyStats.hpp"
 
 using namespace std;
 
@@ -30,6 +32,7 @@ class MySQLDriver {
     const string database;
     const string url;
     ParetoGenerator* PGen;
+    LatencyStats* latencyStats;
 
     /* range between first and last records in metrics */
     unsigned int tsRange;
@@ -41,7 +44,8 @@ public:
 	    const string url) :user(user),
 		    pass(pass),
 		    database(database),
-		    url(url) {}
+		    url(url),
+                    latencyStats((LatencyStats *)nullptr) {}
     void SetGenerator(ParetoGenerator* PG) { PGen=PG; }
     void Prep();
     void Run(unsigned int& minTs, unsigned int& maxTs);
@@ -50,8 +54,10 @@ public:
     /* return max device_id available for given ts */
     unsigned int getMaxDevIdForTS(unsigned int ts);
 
+    void setLatencyStats(LatencyStats* ls);
+
 private:
-    void InsertData();
-    void InsertQuery(unsigned int timestamp, unsigned int device_id, sql::Statement & stmt);
-    void DeleteQuery(unsigned int timestamp, unsigned int device_id, sql::Statement & stmt);
+    void InsertData(int threadId);
+    void InsertQuery(int threadId, unsigned int timestamp, unsigned int device_id, sql::Statement & stmt);
+    void DeleteQuery(int threadId, unsigned int timestamp, unsigned int device_id, sql::Statement & stmt);
 };

--- a/src/Preparer.cpp
+++ b/src/Preparer.cpp
@@ -128,3 +128,8 @@ void Preparer::Run(){
     threadReporter.join();
 }
 
+void Preparer::setLatencyStats(LatencyStats* ls)
+{
+  latencyStats=ls;
+}
+

--- a/src/Preparer.hpp
+++ b/src/Preparer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <stdlib.h>
 #include <iostream>
 #include <iomanip>
@@ -9,6 +10,7 @@
 
 #include "MySQLDriver.hpp"
 #include "Config.hpp"
+#include "LatencyStats.hpp"
 
 /* General class to handle benchmark, not DB specific */
 class Preparer {
@@ -16,6 +18,7 @@ class Preparer {
     std::atomic<unsigned int> insertProgress {0};
     std::atomic<bool> progressLoad {true};
     ParetoGenerator* PGen;
+    LatencyStats* latencyStats=(LatencyStats *)nullptr;
 
 public:
     Preparer(MySQLDriver &ML) :DataLoader(ML) {}
@@ -24,6 +27,8 @@ public:
     void Prep();
     /* Run benchmark itself */
     void Run();
+    /* Pass the LatencyStats object to us */
+    void setLatencyStats(LatencyStats * ls);
 private:
     /* periodical print of prepare progress */
     void prepProgressPrint(unsigned int startTs, unsigned int total) const;

--- a/src/RunningMean.cpp
+++ b/src/RunningMean.cpp
@@ -1,0 +1,22 @@
+#include "RunningMean.hpp"
+
+RunningMean::RunningMean(double v1) {
+  this->v1 = v1;
+  this->n = 1;
+  this->running = 0;
+}
+
+void RunningMean::addSample(double vi)
+{
+  this->n++;
+  this->running += (vi - this->v1);
+}
+
+double RunningMean::mean() {
+  return this->v1 + this->running / this->n;
+}
+
+int64_t RunningMean::samples() {
+  return this->n;
+}
+

--- a/src/RunningMean.hpp
+++ b/src/RunningMean.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <stdint.h>
+
+class RunningMean {
+
+private:
+    int64_t n;
+    double v1;
+    double running;
+
+public:
+    RunningMean(double v1);
+    void addSample(double vi);
+    double mean();
+    int64_t samples();
+};

--- a/src/clean.sh
+++ b/src/clean.sh
@@ -4,10 +4,10 @@ cd `dirname $0`
 
 case $1 in
 
-  all)
+  "all")
     rm -rf CMakeCache.txt CMakeFiles/ Makefile MetricBench cmake_install.cmake .Makefile.swp testBin
     ;;
-  bin*)
+  "all" | "bin*")
     find . -type f -exec file {} \; | grep ELF | cut -d':' -f1 | xargs rm
     ;;
   *)

--- a/src/clean.sh
+++ b/src/clean.sh
@@ -7,7 +7,7 @@ case $1 in
   "all")
     rm -rf CMakeCache.txt CMakeFiles/ Makefile MetricBench cmake_install.cmake .Makefile.swp testBin
     ;;
-  "all" | "bin*")
+  "all" | bin*)
     find . -type f -exec file {} \; | grep ELF | cut -d':' -f1 | xargs rm
     ;;
   *)

--- a/src/clean.sh
+++ b/src/clean.sh
@@ -5,7 +5,7 @@ cd `dirname $0`
 case $1 in
 
   all)
-    rm -rf CMakeCache.txt CMakeFiles/ Makefile MetricBench cmake_install.cmake .Makefile.swp
+    rm -rf CMakeCache.txt CMakeFiles/ Makefile MetricBench cmake_install.cmake .Makefile.swp testBin
     ;;
   bin*)
     find . -type f -exec file {} \; | grep ELF | cut -d':' -f1 | xargs rm

--- a/src/metricbench.cpp
+++ b/src/metricbench.cpp
@@ -53,6 +53,8 @@ int main(int argc, const char **argv)
             "Set storage engine")
 	("engine-extra", po::value<string>(), "Extra storage engine options, e.g. "
 	    "'ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8'")
+        ("csvstats", po::value<string>(&Config::csvStatsFile), "CSV final summary stats file.")
+        ("csvstreams", po::value<string>(&Config::csvStreamingStatsFile), "CSV periodic streaming stats file.")
 	;
 
     po::variables_map vm;

--- a/src/metricbench.cpp
+++ b/src/metricbench.cpp
@@ -16,6 +16,7 @@
 #include "Preparer.hpp"
 #include "Message.hpp"
 #include "Stats.hpp"
+#include "LatencyStats.hpp"
 
 using namespace std;
 
@@ -102,12 +103,15 @@ int main(int argc, const char **argv)
     const string pass(Config::connPass);
     const string database(Config::connDb);
 
+    LatencyStats latencyStats(Config::LoaderThreads);
+
     /* prepare routine */
 
     ParetoGenerator PG(1.04795);
 
     MySQLDriver MLP(user, pass, database, url);
     MLP.SetGenerator(&PG);
+    MLP.setLatencyStats(&latencyStats);
 
     Preparer Runner(MLP);
     Runner.SetGenerator(&PG);
@@ -134,6 +138,10 @@ int main(int argc, const char **argv)
 
             return EXIT_FAILURE;
         }
+
+        // print latency statistics
+        latencyStats.displayLatencyStats();
+
         return EXIT_SUCCESS;
     }
 
@@ -154,6 +162,10 @@ int main(int argc, const char **argv)
 
             return EXIT_FAILURE;
         }
+
+        // print latency statistics
+        latencyStats.displayLatencyStats();
+
         return EXIT_SUCCESS;
     }
 

--- a/src/metricbench.cpp
+++ b/src/metricbench.cpp
@@ -102,61 +102,60 @@ int main(int argc, const char **argv)
     const string pass(Config::connPass);
     const string database(Config::connDb);
 
-
     /* prepare routine */
 
-	ParetoGenerator PG(1.04795);
+    ParetoGenerator PG(1.04795);
 
-	MySQLDriver MLP(user, pass, database, url);
-	MLP.SetGenerator(&PG);
+    MySQLDriver MLP(user, pass, database, url);
+    MLP.SetGenerator(&PG);
 
-	Preparer Runner(MLP);
-	Runner.SetGenerator(&PG);
+    Preparer Runner(MLP);
+    Runner.SetGenerator(&PG);
 
-	Stats st;
+    Stats st;
 
-	std::thread threadStats(&Stats::Run, &st);
-	threadStats.detach();
+    std::thread threadStats(&Stats::Run, &st);
+    threadStats.detach();
 
-	if (runMode == "prepare") {
-	    cout << "PREPARE mode" << endl;
-	    Config::runMode = PREPARE;
-	    try {
+    if (runMode == "prepare") {
+        cout << "PREPARE mode" << endl;
+        Config::runMode = PREPARE;
+        try {
 
-		Runner.Prep();
+            Runner.Prep();
 
-		cout << "# done!" << endl;
+            cout << "# done!" << endl;
 
-	    } catch (std::runtime_error &e) {
+        } catch (std::runtime_error &e) {
 
-		cout << "# ERR: runtime_error in " << __FILE__;
-		cout << "(" << __FUNCTION__ << ") on line " << __LINE__ << endl;
-		cout << "# ERR: " << e.what() << endl;
+            cout << "# ERR: runtime_error in " << __FILE__;
+            cout << "(" << __FUNCTION__ << ") on line " << __LINE__ << endl;
+            cout << "# ERR: " << e.what() << endl;
 
-		return EXIT_FAILURE;
-	    }
-	    return EXIT_SUCCESS;
-	}
+            return EXIT_FAILURE;
+        }
+        return EXIT_SUCCESS;
+    }
 
-	if (runMode == "run") {
-	    cout << "RUN mode" << endl;
-	    Config::runMode = RUN;
-	    try {
+    if (runMode == "run") {
+        cout << "RUN mode" << endl;
+        Config::runMode = RUN;
+        try {
 
-		Runner.Run();
+            Runner.Run();
 
-		cout << "# done!" << endl;
+            cout << "# done!" << endl;
 
-	    } catch (std::runtime_error &e) {
+        } catch (std::runtime_error &e) {
 
-		cout << "# ERR: runtime_error in " << __FILE__;
-		cout << "(" << __FUNCTION__ << ") on line " << __LINE__ << endl;
-		cout << "# ERR: " << e.what() << endl;
+            cout << "# ERR: runtime_error in " << __FILE__;
+            cout << "(" << __FUNCTION__ << ") on line " << __LINE__ << endl;
+            cout << "# ERR: " << e.what() << endl;
 
-		return EXIT_FAILURE;
-	    }
-	    return EXIT_SUCCESS;
-	}
+            return EXIT_FAILURE;
+        }
+        return EXIT_SUCCESS;
+    }
 
-	return EXIT_SUCCESS;
+    return EXIT_SUCCESS;
 }

--- a/src/pareto.hpp
+++ b/src/pareto.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <random>
+#include <stdexcept>
 
 /* based on an article "Power laws, Pareto distributions and Zipf's law" M. E. J. Newman */
 /* pareto_h = 1.16096 corresponds to 80-20 rule

--- a/src/test/LatencyStatsTest.cpp
+++ b/src/test/LatencyStatsTest.cpp
@@ -1,0 +1,17 @@
+#include "../LatencyStats.hpp"
+
+#define BOOST_TEST_MODULE LatencyStatsTest
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE( latency_stats_test )
+{
+  for (int64_t us = 0; us < 100 * 1000 * 1000; us += 100) {
+    int32_t bucket = LatencyStats::latencyToBucket(us);
+    BOOST_CHECK(bucket >= 0);
+    BOOST_CHECK(bucket < LatencyStats::NUM_BUCKETS);
+    LatencyStats::MinMaxMS range = LatencyStats::bucketBound(bucket);
+    BOOST_CHECK(us >= range[0]);
+    BOOST_CHECK(us <= range[1]);
+  }
+}
+

--- a/src/test/TemplateTest.cpp
+++ b/src/test/TemplateTest.cpp
@@ -1,0 +1,12 @@
+// include files here
+
+#define BOOST_TEST_MODULE NameOfTest
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE( name_of_test )
+{
+  bool val=true;
+
+  BOOST_CHECK(val);
+}
+


### PR DESCRIPTION
Max / Mean latency report correctly for each operation at the end of a run.   Percentile reporting still needs work.   Functions for CSV output are in the LatencyStats class.   They still need to be integrated with the Stats progress thread (streaming) and metricbench.cpp (total)
